### PR TITLE
Remove unused muts

### DIFF
--- a/examples/mwalib-data-dump.rs
+++ b/examples/mwalib-data-dump.rs
@@ -57,7 +57,7 @@ fn dump_data<T: AsRef<std::path::Path>>(
 ) -> Result<(), anyhow::Error> {
     let mut dump_file = File::create(dump_filename)?;
     println!("Dumping data via mwalib...");
-    let mut context = CorrelatorContext::new(metafits, files)?;
+    let context = CorrelatorContext::new(metafits, files)?;
     let coarse_chan_array = context.coarse_chans.clone();
     let timestep_array = context.timesteps.clone();
 

--- a/examples/mwalib-sum-first-fine-channel-gpubox-hdus.rs
+++ b/examples/mwalib-sum-first-fine-channel-gpubox-hdus.rs
@@ -30,7 +30,7 @@ struct Opt {
 fn main() -> Result<(), anyhow::Error> {
     let opts = Opt::from_args();
 
-    let mut context = CorrelatorContext::new(&opts.metafits, &opts.files)?;
+    let context = CorrelatorContext::new(&opts.metafits, &opts.files)?;
     if context.corr_version != CorrelatorVersion::V2 {
         bail!("Input data is not MWAX data; exiting.");
     }

--- a/examples/mwalib-sum-gpubox-hdus.rs
+++ b/examples/mwalib-sum-gpubox-hdus.rs
@@ -53,7 +53,7 @@ fn sum_direct(files: Vec<std::path::PathBuf>) -> Result<(), anyhow::Error> {
 #[cfg(not(tarpaulin_include))]
 fn sum_mwalib<T: AsRef<std::path::Path>>(metafits: &T, files: &[T]) -> Result<(), anyhow::Error> {
     println!("Summing via mwalib using read_by_baseline()...");
-    let mut context = CorrelatorContext::new(metafits, files)?;
+    let context = CorrelatorContext::new(metafits, files)?;
     println!("Correlator version: {}", context.corr_version);
 
     let mut sum: f64 = 0.0;

--- a/src/convert/test.rs
+++ b/src/convert/test.rs
@@ -293,7 +293,7 @@ fn test_conversion_of_legacy_hdu_to_mwax_frequency_order_vs_pyuvdata() {
     let metafits = "test_files/1101503312_1_timestep/1101503312.metafits";
     let gpuboxfiles =
         vec!["test_files/1101503312_1_timestep/1101503312_20141201210818_gpubox01_00.fits"];
-    let mut context =
+    let context =
         CorrelatorContext::new(&metafits, &gpuboxfiles).expect("Failed to create mwalibContext");
 
     // Read and convert first HDU
@@ -637,7 +637,7 @@ fn test_mwax_conversion_to_frequency_order() {
     //
     // Open a context and load in a test metafits and gpubox file
     let gpuboxfiles = vec![mwax_filename];
-    let mut context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
+    let context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
         .expect("Failed to create mwalibContext");
 
     // Read and convert first HDU

--- a/src/convert/test.rs
+++ b/src/convert/test.rs
@@ -139,7 +139,7 @@ fn test_conversion_of_legacy_hdu_to_mwax_baseline_ordervs_pyuvdata() {
     let metafits = "test_files/1101503312_1_timestep/1101503312.metafits";
     let gpuboxfiles =
         vec!["test_files/1101503312_1_timestep/1101503312_20141201210818_gpubox01_00.fits"];
-    let mut context = CorrelatorContext::new(&metafits, &gpuboxfiles)
+    let context = CorrelatorContext::new(&metafits, &gpuboxfiles)
         .expect("Failed to create CorrelatorContext");
 
     // Read and convert first HDU
@@ -459,7 +459,7 @@ fn test_conversion_of_legacy_hdu_to_mwax_baseline_order_vs_cotter() {
     let metafits = "test_files/1101503312_1_timestep/1101503312.metafits";
     let gpuboxfiles =
         vec!["test_files/1101503312_1_timestep/1101503312_20141201210818_gpubox01_00.fits"];
-    let mut context = CorrelatorContext::new(&metafits, &gpuboxfiles)
+    let context = CorrelatorContext::new(&metafits, &gpuboxfiles)
         .expect("Failed to create CorrelatorContext");
 
     // Read and convert first HDU

--- a/src/correlator_context/mod.rs
+++ b/src/correlator_context/mod.rs
@@ -301,7 +301,7 @@ impl CorrelatorContext {
     ///
     ///
     pub fn read_by_frequency(
-        &mut self,
+        &self,
         timestep_index: usize,
         coarse_chan_index: usize,
     ) -> Result<Vec<f32>, GpuboxError> {

--- a/src/correlator_context/mod.rs
+++ b/src/correlator_context/mod.rs
@@ -225,7 +225,7 @@ impl CorrelatorContext {
     ///
     ///
     pub fn read_by_baseline(
-        &mut self,
+        &self,
         timestep_index: usize,
         coarse_chan_index: usize,
     ) -> Result<Vec<f32>, GpuboxError> {
@@ -528,11 +528,11 @@ impl fmt::Display for CorrelatorContext {
             Actual duration:          {duration} s,
 
             num timesteps:            {n_timesteps},
-            timesteps:                {timesteps:?},           
+            timesteps:                {timesteps:?},
 
             observation bandwidth:    {obw} MHz,
             num coarse channels,      {n_coarse},
-            coarse channels:          {coarse:?},            
+            coarse channels:          {coarse:?},
 
             gpubox HDU size:          {hdu_size} MiB,
             Memory usage per scan:    {scan_size} MiB,

--- a/src/correlator_context/test.rs
+++ b/src/correlator_context/test.rs
@@ -120,7 +120,7 @@ fn test_read_by_baseline_invalid_inputs() {
 
     // Open a context and load in a test metafits and gpubox file
     let gpuboxfiles = vec![mwax_filename];
-    let mut context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
+    let context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
         .expect("Failed to create CorrelatorContext");
 
     // 99999 is invalid as a timestep for this observation

--- a/src/correlator_context/test.rs
+++ b/src/correlator_context/test.rs
@@ -93,7 +93,7 @@ fn test_read_by_frequency_invalid_inputs() {
 
     // Open a context and load in a test metafits and gpubox file
     let gpuboxfiles = vec![mwax_filename];
-    let mut context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
+    let context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
         .expect("Failed to create CorrelatorContext");
 
     // 99999 is invalid as a timestep for this observation
@@ -155,7 +155,7 @@ fn test_mwa_legacy_read() {
     //
     // Open a context and load in a test metafits and gpubox file
     let gpuboxfiles = vec![mwax_filename];
-    let mut context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
+    let context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
         .expect("Failed to create CorrelatorContext");
 
     // Read and convert first HDU by baseline
@@ -202,7 +202,7 @@ fn test_mwax_read() {
     //
     // Open a context and load in a test metafits and gpubox file
     let gpuboxfiles = vec![mwax_filename];
-    let mut context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
+    let context = CorrelatorContext::new(&mwax_metafits_filename, &gpuboxfiles)
         .expect("Failed to create CorrelatorContext");
 
     // Read and convert first HDU by baseline


### PR DESCRIPTION
There are several places where a mutable reference to a context is un-necessary:
- read_by_baseline
- read_by_frequency
- probably elsewhere in vcs_support

removing these muts makes it easier to use context in parallel workflows, and all of the tests still pass.