### PR TITLE
Allow cfitsio code 204 to proceed.

### DIFF
--- a/src/fits_read/mod.rs
+++ b/src/fits_read/mod.rs
@@ -348,7 +348,7 @@ pub fn _get_optional_fits_key<T: std::str::FromStr>(
         Ok(key_value) => key_value,
         Err(e) => match &e {
             fitsio::errors::Error::Fits(fe) => match fe.status {
-                202 => return Ok(None),
+                202 | 204 => return Ok(None),
                 _ => {
                     return Err(FitsError::Fitsio {
                         fits_error: e,


### PR DESCRIPTION
When attempting to access a key without *any* value against it, cfitsio
returns code 204. Our get_optional_fits_key function handled this code
by returning a generic error, which (not very helpfully) prints "keyword
value is undefined" and aborts. This commit makes the function return
None when there is no value to retrieve.