### PR TITLE
Modernise examples with clap 3.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [features]
 # Compile cfitsio from source and link it statically.
 cfitsio-static = ["fitsio-sys/fitsio-src"]
+# Enable optional features needed by examples.
+examples = ["anyhow", "clap", "env_logger"]
 
 [dependencies]
 chrono = "0.4.*"
@@ -40,15 +42,35 @@ rayon = "~1"
 regex = "~1"
 thiserror = "1.0.*"
 
+anyhow = { version = "1.0.*", optional = true }
+clap = { version = "3.0.*", features = ["derive"], optional = true }
+env_logger = { version = "0.9.*", optional = true }
+
 [dev-dependencies]
-anyhow = "1.0.*"
 csv = "1.1.*"
-env_logger = "0.9.*"
 float-cmp = "0.9.*"
-structopt = "0.3.*"
 tempdir = "0.3.*"
-cbindgen = "0.*"
 
 [build-dependencies]
 built = "0.*"
 cbindgen = "0.*"
+
+[[example]]
+name = "mwalib-data-dump"
+required-features = ["examples"]
+
+[[example]]
+name = "mwalib-print-corr-context"
+required-features = ["examples"]
+
+[[example]]
+name = "mwalib-print-volt-context"
+required-features = ["examples"]
+
+[[example]]
+name = "mwalib-sum-gpubox-hdus"
+required-features = ["examples"]
+
+[[example]]
+name = "mwalib-sum-first-fine-channel-gpubox-hdus"
+required-features = ["examples"]

--- a/examples/mwalib-data-dump.rs
+++ b/examples/mwalib-data-dump.rs
@@ -4,43 +4,43 @@
 
 /// Given gpubox files, provide a way to output/dump visibilities.
 use anyhow::*;
+use clap::Parser;
 use mwalib::*;
 use std::fs::File;
 use std::io::Write;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "mwalib-data-dump", author)]
+#[derive(Parser, Debug)]
+#[clap(name = "mwalib-data-dump", author)]
 struct Opt {
     /// timestep number (0 indexed)
-    #[structopt(short, long)]
+    #[clap(short, long)]
     timestep: usize,
 
     /// baseline number (0 indexed)
-    #[structopt(short, long)]
+    #[clap(short, long)]
     baseline: usize,
 
     /// Fine channel to start with
-    #[structopt(long)]
+    #[clap(long)]
     fine_chan1: usize,
     /// Fine channel to end with
-    #[structopt(long)]
+    #[clap(long)]
     fine_chan2: usize,
 
     /// Coarse channel
-    #[structopt(long)]
+    #[clap(long)]
     coarse_chan: usize,
 
     /// Path to the metafits file.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     metafits: std::path::PathBuf,
 
     /// Paths to the gpubox files.
-    #[structopt(name = "GPUBOX FILE", parse(from_os_str))]
+    #[clap(name = "GPUBOX FILE", parse(from_os_str))]
     files: Vec<std::path::PathBuf>,
 
     // Dump filename
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     dump_filename: std::path::PathBuf,
 }
 
@@ -145,7 +145,7 @@ fn dump_data<T: AsRef<std::path::Path>>(
 
 fn main() -> Result<(), anyhow::Error> {
     env_logger::try_init().unwrap_or(());
-    let opts = Opt::from_args();
+    let opts = Opt::parse();
 
     dump_data(
         &opts.metafits,

--- a/examples/mwalib-print-corr-context.rs
+++ b/examples/mwalib-print-corr-context.rs
@@ -12,25 +12,25 @@
 // $ export RUST_LOG=mwalib=debug
 //
 use anyhow::*;
-use structopt::StructOpt;
+use clap::Parser;
 
 use mwalib::*;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "mwalib-print-obs-context", author)]
+#[derive(Parser, Debug)]
+#[clap(name = "mwalib-print-obs-context", author)]
 struct Opt {
     /// The path to an observation's metafits file.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     metafits: std::path::PathBuf,
 
     /// Paths to the observation's gpubox files.
-    #[structopt(name = "GPUBOX FILE", parse(from_os_str))]
+    #[clap(name = "GPUBOX FILE", parse(from_os_str))]
     files: Vec<std::path::PathBuf>,
 }
 
 fn main() -> Result<(), anyhow::Error> {
     env_logger::try_init().unwrap_or(());
-    let opts = Opt::from_args();
+    let opts = Opt::parse();
     let context = CorrelatorContext::new(&opts.metafits, &opts.files)?;
 
     println!("{}", context);

--- a/examples/mwalib-print-volt-context.rs
+++ b/examples/mwalib-print-volt-context.rs
@@ -5,25 +5,25 @@
 /// Given an voltage observation's data, verify that `mwalib` is functioning correctly
 /// by printing an observation context.
 use anyhow::*;
-use structopt::StructOpt;
+use clap::Parser;
 
 use mwalib::*;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "mwalib-print-volt-context", author)]
+#[derive(Parser, Debug)]
+#[clap(name = "mwalib-print-volt-context", author)]
 struct Opt {
     /// The path to an observation's metafits file.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     metafits: std::path::PathBuf,
 
     /// Paths to the observation's voltage files.
-    #[structopt(name = "VOLTAGE FILE", parse(from_os_str))]
+    #[clap(name = "VOLTAGE FILE", parse(from_os_str))]
     files: Vec<std::path::PathBuf>,
 }
 
 fn main() -> Result<(), anyhow::Error> {
     env_logger::try_init().unwrap_or(());
-    let opts = Opt::from_args();
+    let opts = Opt::parse();
     let context = VoltageContext::new(&opts.metafits, &opts.files)?;
 
     println!("{}", context);

--- a/examples/mwalib-sum-first-fine-channel-gpubox-hdus.rs
+++ b/examples/mwalib-sum-first-fine-channel-gpubox-hdus.rs
@@ -8,27 +8,27 @@
 ///
 /// Works only on MWAX data for now.
 use anyhow::*;
-use structopt::StructOpt;
+use clap::Parser;
 
 use mwalib::*;
 
 #[cfg(not(tarpaulin_include))]
-#[derive(StructOpt, Debug)]
-#[structopt(name = "mwalib-sum-first-fine-channel-gpubox-hdus", author)]
+#[derive(Parser, Debug)]
+#[clap(name = "mwalib-sum-first-fine-channel-gpubox-hdus", author)]
 struct Opt {
     /// Path to the metafits file.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     metafits: std::path::PathBuf,
 
     /// Paths to the gpubox files.
-    #[structopt(name = "GPUBOX FILE", parse(from_os_str))]
+    #[clap(name = "GPUBOX FILE", parse(from_os_str))]
     files: Vec<std::path::PathBuf>,
 }
 
 #[cfg(not(tarpaulin_include))]
 #[allow(clippy::needless_range_loop)] // Ignoring this, as it is a false positive
 fn main() -> Result<(), anyhow::Error> {
-    let opts = Opt::from_args();
+    let opts = Opt::parse();
 
     let context = CorrelatorContext::new(&opts.metafits, &opts.files)?;
     if context.mwa_version != MWAVersion::CorrMWAXv2 {

--- a/examples/mwalib-sum-gpubox-hdus.rs
+++ b/examples/mwalib-sum-gpubox-hdus.rs
@@ -4,25 +4,25 @@
 
 /// Given gpubox files, add the contents of their HDUs and report the sum.
 use anyhow::*;
+use clap::Parser;
 use core::result::Result::Ok;
 use mwalib::*;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "mwalib-sum-gpubox-hdus", author)]
+#[derive(Parser, Debug)]
+#[clap(name = "mwalib-sum-gpubox-hdus", author)]
 struct Opt {
     /// Don't use mwalib - just iterate over the HDUs and add them. The result
     /// might be different because the start/end times of the observation may
     /// not be consistent.
-    #[structopt(long)]
+    #[clap(long)]
     direct: bool,
 
     /// Path to the metafits file.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     metafits: std::path::PathBuf,
 
     /// Paths to the gpubox files.
-    #[structopt(name = "GPUBOX FILE", parse(from_os_str))]
+    #[clap(name = "GPUBOX FILE", parse(from_os_str))]
     files: Vec<std::path::PathBuf>,
 }
 
@@ -85,7 +85,7 @@ fn sum_mwalib<T: AsRef<std::path::Path>>(metafits: &T, files: &[T]) -> Result<()
 
 fn main() -> Result<(), anyhow::Error> {
     env_logger::try_init().unwrap_or(());
-    let opts = Opt::from_args();
+    let opts = Opt::parse();
     if opts.direct {
         sum_direct(opts.files)?;
     } else {


### PR DESCRIPTION
This commit introduces an "examples" feature. With its existence,
example-only dependencies are now not compiled by default. However,
running examples is a little more annoying as cargo needs
--features=examples provided. This may not be desired; if not, the
Cargo.toml changes can be almost entirely reverted.

Remove cbindgen from the dev-dependencies; this shouldn't have been
necessary.