### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -249,6 +249,8 @@ jobs:
 
   rust_release:
     name: Publish to crates.io
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: [create-github-release]


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/9](https://github.com/MWATelescope/mwalib/security/code-scanning/9)

To fix this issue, add a `permissions` block to the `rust_release` job, specifying only the minimum access needed. For publishing to crates.io, the action uses the `CARGO_REGISTRY_TOKEN` secret and does not require `GITHUB_TOKEN` write access; read access to `contents` is typically sufficient. Place the following block just under the `name:` field in the `rust_release` job:

```yaml
permissions:
  contents: read
```

This restricts GitHub token access, adhering to least privilege. No other code or import changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
