### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,6 @@
 name: Cross-platform tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/6](https://github.com/MWATelescope/mwalib/security/code-scanning/6)

To fix the detected issue, we need to add a `permissions` block to the workflow. The best place to do this is at the root of the YAML file, so it applies to all jobs unless overridden. From analysis of all the steps, only reading repository contents is required (for `actions/checkout`), and none of the steps need further access (such as pull requests or issues write). Thus, we should set `permissions: contents: read` immediately after the `name` and before `on` at the top of the file. No further changes or imports are necessary. This limits the GITHUB_TOKEN to read-only access for contents and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
