### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_cfitsio_tests.yml
+++ b/.github/workflows/run_cfitsio_tests.yml
@@ -13,6 +13,8 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
 
+permissions:
+  contents: read
 jobs:
   test_cfitsio_3:
     name: Test cfitsio 3.49 on ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/5](https://github.com/MWATelescope/mwalib/security/code-scanning/5)

To fix the issue, we should add a `permissions` block explicitly to the workflow to restrict the permissions granted to the GITHUB_TOKEN. This can be done at the workflow level (top of the file before the `jobs:` block), or individually at the job level. Since both jobs use the same steps and do not require write permissions, it's best (and simplest) to set the permissions at the workflow level. The recommended minimal value is `contents: read`, which will allow jobs to perform source code checkout but will not permit any changes to repository contents. No new imports or dependencies are required; simply insert the required YAML at the correct location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
