### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_cfitsio_tests.yml
+++ b/.github/workflows/run_cfitsio_tests.yml
@@ -1,4 +1,6 @@
 name: cfitsio tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/4](https://github.com/MWATelescope/mwalib/security/code-scanning/4)

To fix the issue, add a `permissions` block at the top level of the workflow YAML (before the `jobs:` key) to restrict the GITHUB_TOKEN permissions. The best minimal set for a test-only workflow is `contents: read`, which allows reading repository contents used by `actions/checkout` but disallows all write operations. This will apply to all jobs unless overridden. Add the following block after the workflow name and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports or complex changes; only a single YAML block addition to `.github/workflows/run_cfitsio_tests.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
