### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,6 +11,8 @@
 #    maturin generate-ci github --platform manylinux macos
 #
 name: Releasev2
+permissions:
+  contents: read
 
 on:
   push:
@@ -194,6 +196,8 @@ jobs:
   create-github-release:
     name: Create a new github release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: [build_linux, build_macos]    
     environment: CI


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/3](https://github.com/MWATelescope/mwalib/security/code-scanning/3)

The best way to fix this problem is to add an explicit `permissions:` block at the *root* of the workflow with the least necessary privileges (for example, `contents: read`). This will apply a minimum-permission scope to all jobs, reducing the risk of privilege escalation from default GITHUB_TOKEN permissions. For jobs that require stricter permissions to function (such as those involved in creating GitHub releases, uploading to PyPI, or manipulating repository contents), add additional `permissions:` blocks *within the specific jobs*, explicitly enumerating only the permissions required for each action.

**In concrete terms:**
- Add to the top of the file (below `name:`)  
  ```yaml
  permissions:
    contents: read
  ```
  This applies to all jobs by default.
- For jobs such as `create-github-release`, override the block locally to permit writing releases. Example:
  ```yaml
    permissions:
      contents: write
  ```
- Analyze other jobs (e.g., `pypi_release`, `crates_publish`) and set their permissions as per documented requirements (usually still only `contents: read`).

These changes are all within the `.github/workflows/releases.yml` file and can be implemented by modifying the shown code snippets accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
