### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_python_tests.yml
+++ b/.github/workflows/run_python_tests.yml
@@ -1,4 +1,6 @@
 name: Python tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/2](https://github.com/MWATelescope/mwalib/security/code-scanning/2)

To fix this issue, a `permissions:` block should be added to the workflow to explicitly set the minimal required permissions for the provided job(s). In this case, the workflow only requires read-only access to repository contents (for source code checkout), so we add `permissions: contents: read` at either the root level or the job level. The most common and clear convention is to add this block at the workflow root (just after the `name:` or `on:`), ensuring all jobs inherit these read-only permissions unless otherwise specified. No additional imports or definitions are necessary. The only change needed is inserting this block as the second top-level key in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
