### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,8 @@ env:
 jobs:
   generate_coverage:
     runs-on: ubuntu-latest    
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout sources


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/1](https://github.com/MWATelescope/mwalib/security/code-scanning/1)

To fix the problem, add a `permissions` key to the job (or workflow root) to set minimally required GITHUB_TOKEN permissions. Since no job in the workflow requires write access to repository contents, and the only upload is via a dedicated Codecov token (not GITHUB_TOKEN), the correct minimal permission is most likely `contents: read`. You should add this block either at the workflow root (top-level, before `env:` or `jobs:`), or within the `generate_coverage` job. In this case, adding it at the job level (line 18, directly under `generate_coverage:`) best matches the CodeQL suggestion ("Consider setting an explicit permissions block, using the following as a minimal starting point: {{contents: read}}"). No other imports or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
