### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -193,6 +193,8 @@ jobs:
 
   create-github-release:
     name: Create a new github release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: [build_linux, build_macos]    


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/8](https://github.com/MWATelescope/mwalib/security/code-scanning/8)

To fix this problem, add a `permissions` block to the `create-github-release` job, explicitly granting only the permissions necessary for the job to complete. For creating releases, the minimal required permission is usually `contents: write`. You do not need `id-token` or `attestations` permissions here. This change should be implemented by inserting the following block just after the job name on line 195:

```yaml
permissions:
  contents: write
```

Ensure this block is added only to the `create-github-release` job. No other jobs require changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
