### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,6 +11,8 @@
 #    maturin generate-ci github --platform manylinux macos
 #
 name: Releasev2
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/mwalib/security/code-scanning/7](https://github.com/MWATelescope/mwalib/security/code-scanning/7)

To fix the problem, you should add a `permissions:` key near the top of the workflow (at the root level, after `name:` and before or after `on:` and `env:`), setting it to the minimum required for the majority of jobs. The CodeQL suggestion is `{contents: read}`, which will ensure all jobs have read-only default GitHub token access unless overridden. Later, for jobs that need to create releases or publish (such as `create-github-release` or `pypi_release`), you may override with stronger permissions as needed, but the basic remediation is simply the addition of the root-level `permissions: contents: read`.

**Steps:**

- Insert the following block at the root level of the YAML (recommended after `name:` for clarity, before `on:` or `env:`):

  ```yaml
  permissions:
    contents: read
  ```

No extra packages, methods, or imports are necessary for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
